### PR TITLE
PS-1106 Map Update with GeoJSON

### DIFF
--- a/GeoJsonSharp.Tests/GeoJsonSharp.Tests.csproj
+++ b/GeoJsonSharp.Tests/GeoJsonSharp.Tests.csproj
@@ -1,7 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
+    <IsPublishable>False</IsPublishable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/GeoJsonSharp.Tests/GeoJsonSharp.Tests.csproj
+++ b/GeoJsonSharp.Tests/GeoJsonSharp.Tests.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="NetTopologySuite" Version="1.15.3" />
     <PackageReference Include="NetTopologySuite.Features" Version="1.15.1" />
     <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GeoJsonSharp.Tests/Parse/GeoJsonParserTest.cs
+++ b/GeoJsonSharp.Tests/Parse/GeoJsonParserTest.cs
@@ -1,33 +1,56 @@
 ﻿using System;
+
 using GeoJsonSharp.Parse;
+
 using NUnit.Framework;
 
 namespace GeoJsonSharp.Tests.Parse
 {
-    /// <summary>
-    /// The geo json parser test.
-    /// </summary>
-    public class GeoJsonParserTest
-    {
-        /// <summary>
-        /// The parse feature with date property.
-        /// </summary>
-        [Test]
-        public void ParseFeatureWithDateProperty()
-        {
-            // Arrange
+	/// <summary>
+	/// The geo json parser test.
+	/// </summary>
+	public class GeoJsonParserTest
+	{
+		/// <summary>
+		/// The parse feature with date property.
+		/// </summary>
+		[Test]
+		public void ParseFeatureWithDateProperty()
+		{
+			// Arrange
 
-            // GeoJSON FeatureCollection having one feature
-            // Feature has property - name:'processed' and is of type 'DateTime'
-            var geoJsonString = "{\"type\": \"FeatureCollection\",\"crs\": { \"type\": \"name\", \"properties\": { \"name\": \"urn:ogc:def:crs:EPSG::4283\" } },\"features\": [{\"type\": \"Feature\",\"properties\": {\"title\": \"Feature with date property\",\"processed\": \"2015-08-10T11:10:38-00:00\"},\"geometry\": {\"type\": \"Point\",\"coordinates\": [ 152.7465, -31.1015 ]}}]}";
+			// GeoJSON FeatureCollection having one feature
+			// Feature has property - name:'processed' and is of type 'DateTime'
+			var geoJsonString = "{\"type\": \"FeatureCollection\",\"crs\": { \"type\": \"name\", \"properties\": { \"name\": \"urn:ogc:def:crs:EPSG::4283\" } },\"features\": [{\"type\": \"Feature\",\"properties\": {\"title\": \"Feature with date property\",\"processed\": \"2015-08-10T11:10:38-00:00\"},\"geometry\": {\"type\": \"Point\",\"coordinates\": [ 152.7465, -31.1015 ]}}]}";
 
-            // Act
-            var geoParser = new GeoJsonParser(geoJsonString, new ParserSettings {SkipInvalidGeometry = false});
-            var featureCollection = geoParser.Parse();
-            var processed = featureCollection.Features[0].Attributes["processed"];
+			// Act
+			var geoParser = new GeoJsonParser(geoJsonString, new ParserSettings { SkipInvalidGeometry = false });
+			var featureCollection = geoParser.Parse();
+			var processed = featureCollection.Features[0].Attributes["processed"];
 
-            // Assert
-            Assert.That(processed, Is.InstanceOf<DateTime>());
-        }
-    }
+			// Assert
+			Assert.That(processed, Is.InstanceOf<DateTime>());
+		}
+
+		/// <summary>
+		/// The parse feature collection with name property.
+		/// </summary>
+		[Test]
+		public void ParseFeatureCollectionWithNameDateProperty()
+		{
+			// Arrange
+
+			// GeoJSON FeatureCollection having one feature
+			// Feature has property - name:'processed' and is of type 'DateTime'
+			var geoJsonString = "{\"type\": \"FeatureCollection\",\"name\": \"SomeName\", \"crs\": { \"type\": \"name\", \"properties\": { \"name\": \"urn:ogc:def:crs:EPSG::4283\" } },\"features\": [{\"type\": \"Feature\",\"properties\": {\"title\": \"Feature with date property\",\"processed\": \"2015-08-10T11:10:38-00:00\"},\"geometry\": {\"type\": \"Point\",\"coordinates\": [ 152.7465, -31.1015 ]}}]}";
+
+			// Act
+			var geoParser = new GeoJsonParser(geoJsonString, new ParserSettings { SkipInvalidGeometry = false });
+			var featureCollection = geoParser.Parse();
+			var processed = featureCollection.Features[0].Attributes["processed"];
+
+			// Assert
+			Assert.That(processed, Is.InstanceOf<DateTime>());
+		}
+	}
 }

--- a/GeoJsonSharp.sln
+++ b/GeoJsonSharp.sln
@@ -1,9 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33516.290
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GeoJsonSharp", "GeoJsonSharp\GeoJsonSharp.csproj", "{AC05CCBD-B50D-4AB1-BF31-F1A14005B97F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GeoJsonSharp", "GeoJsonSharp\GeoJsonSharp.csproj", "{AC05CCBD-B50D-4AB1-BF31-F1A14005B97F}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{429F3AC9-1D2D-4AF8-9738-C4F5A92CDCC6}"
 	ProjectSection(SolutionItems) = preProject
@@ -12,7 +12,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{429F3A
 		.nuget\NuGet.targets = .nuget\NuGet.targets
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GeoJsonSharp.Tests", "GeoJsonSharp.Tests\GeoJsonSharp.Tests.csproj", "{7359AF86-3275-4E2F-802A-4B5131B90FDC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GeoJsonSharp.Tests", "GeoJsonSharp.Tests\GeoJsonSharp.Tests.csproj", "{7359AF86-3275-4E2F-802A-4B5131B90FDC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -31,5 +31,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {BBCF7FFC-FE5E-49E1-82F2-53892255F95F}
 	EndGlobalSection
 EndGlobal

--- a/GeoJsonSharp/GeoJsonSharp.csproj
+++ b/GeoJsonSharp/GeoJsonSharp.csproj
@@ -9,10 +9,10 @@
     <PackageTags>GeoJSON NTS</PackageTags>
     <PackageReleaseNotes>Add .Net Standard support</PackageReleaseNotes>
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
-    <AssemblyVersion>1.0.4.0</AssemblyVersion>
-    <FileVersion>1.0.4.0</FileVersion>
-    <Version>1.0.4</Version>
-    <VersionPrefix>1.0.4</VersionPrefix>
+    <AssemblyVersion>1.0.5.0</AssemblyVersion>
+    <FileVersion>1.0.5.0</FileVersion>
+    <Version>1.0.5</Version>
+    <VersionPrefix>1.0.5</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Title>GeoJsonSharp</Title>
     <Company>Smartrak</Company>
@@ -22,7 +22,7 @@
   <ItemGroup>
     <PackageReference Include="NetTopologySuite" Version="1.15.3" />
     <PackageReference Include="NetTopologySuite.Features" Version="1.15.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
 </Project>

--- a/GeoJsonSharp/GeoJsonSharp.csproj
+++ b/GeoJsonSharp/GeoJsonSharp.csproj
@@ -9,10 +9,10 @@
     <PackageTags>GeoJSON NTS</PackageTags>
     <PackageReleaseNotes>Add .Net Standard support</PackageReleaseNotes>
     <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
-    <AssemblyVersion>1.0.3.0</AssemblyVersion>
-    <FileVersion>1.0.3.0</FileVersion>
-    <Version>1.0.3</Version>
-    <VersionPrefix>1.0.3</VersionPrefix>
+    <AssemblyVersion>1.0.4.0</AssemblyVersion>
+    <FileVersion>1.0.4.0</FileVersion>
+    <Version>1.0.4</Version>
+    <VersionPrefix>1.0.4</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Title>GeoJsonSharp</Title>
     <Company>Smartrak</Company>

--- a/GeoJsonSharp/Parse/GeoJsonParser.cs
+++ b/GeoJsonSharp/Parse/GeoJsonParser.cs
@@ -98,6 +98,13 @@ namespace GeoJsonSharp.Parse
 
 			AssertRead(JsonToken.PropertyName);
 
+			if ((string)Reader.Value == "name")
+			{
+				AssertRead(JsonToken.String);
+
+				AssertRead(JsonToken.PropertyName);
+			}
+
 			if ((string)Reader.Value == "crs")
 			{
 				CRSBase crs;


### PR DESCRIPTION
As part of https://smartrak.atlassian.net/browse/PS-1106 it was discovered that our GeoJSON parser breaks when "name" property is present, as is now the case with Fonterra-supplied files. Added the code to read and ignore the property, if present.